### PR TITLE
fix case when result is {}

### DIFF
--- a/src/soundcharts/artist.py
+++ b/src/soundcharts/artist.py
@@ -217,7 +217,7 @@ class Artist:
         endpoint = f"/api/v2/artist/{artist_uuid}/audience/{platform}"
         params = {"startDate": start_date, "endDate": end_date}
         result = request_looper(endpoint, params)
-        return {} if result is None else sort_items_by_date(result)
+        return {} if result is None or len(result)==0 else sort_items_by_date(result)
 
     @staticmethod
     def get_local_audience(


### PR DESCRIPTION
result can be an empty dict. In this case `api_utils.sort_by_items_date(result)` will throw an error.

The error can be reproduced with:
`sc.artist.get_audience("11e81bce-064a-72dc-85d8-a0369fe50396'", "facebook", end_date="'2019-01-03'")`
 
